### PR TITLE
Fix CA header duplication

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -53,11 +53,10 @@ newclient () {
 
 # Generates custom CLIENT-withoutobfs.ovpn file
 newclientwithout () {
-	cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
-	echo "</ca>" >> ~/$1-withoutobfs.ovpn
+        cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
+        echo "<ca>" >> ~/$1-withoutobfs.ovpn
+        cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
+        echo "</ca>" >> ~/$1-withoutobfs.ovpn
 	echo "<cert>" >> ~/$1-withoutobfs.ovpn
 	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> ~/$1-withoutobfs.ovpn
 	echo "</cert>" >> ~/$1-withoutobfs.ovpn

--- a/setup_UDP.sh
+++ b/setup_UDP.sh
@@ -53,11 +53,10 @@ newclient () {
 
 # Generates custom CLIENT-withoutobfs.ovpn file
 newclientwithout () {
-	cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
-	echo "</ca>" >> ~/$1-withoutobfs.ovpn
+        cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
+        echo "<ca>" >> ~/$1-withoutobfs.ovpn
+        cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
+        echo "</ca>" >> ~/$1-withoutobfs.ovpn
 	echo "<cert>" >> ~/$1-withoutobfs.ovpn
 	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> ~/$1-withoutobfs.ovpn
 	echo "</cert>" >> ~/$1-withoutobfs.ovpn


### PR DESCRIPTION
## Summary
- clean up `newclientwithout` functions in both setup scripts to remove duplicate `<ca>` line

## Testing
- `shellcheck setup.sh setup_UDP.sh`

------
https://chatgpt.com/codex/tasks/task_e_684247f6867c832c9873e26b463aac8e