### PR TITLE
Fix duplicate CA block in client config generation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -53,11 +53,10 @@ newclient () {
 
 # Generates custom CLIENT-withoutobfs.ovpn file
 newclientwithout () {
-	cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
-	echo "</ca>" >> ~/$1-withoutobfs.ovpn
+        cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
+        echo "<ca>" >> ~/$1-withoutobfs.ovpn
+        cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
+        echo "</ca>" >> ~/$1-withoutobfs.ovpn
 	echo "<cert>" >> ~/$1-withoutobfs.ovpn
 	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> ~/$1-withoutobfs.ovpn
 	echo "</cert>" >> ~/$1-withoutobfs.ovpn

--- a/setup_UDP.sh
+++ b/setup_UDP.sh
@@ -53,11 +53,10 @@ newclient () {
 
 # Generates custom CLIENT-withoutobfs.ovpn file
 newclientwithout () {
-	cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	echo "<ca>" >> ~/$1-withoutobfs.ovpn
-	cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
-	echo "</ca>" >> ~/$1-withoutobfs.ovpn
+        cp /etc/openvpn/client-without-common.txt ~/$1-withoutobfs.ovpn
+        echo "<ca>" >> ~/$1-withoutobfs.ovpn
+        cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1-withoutobfs.ovpn
+        echo "</ca>" >> ~/$1-withoutobfs.ovpn
 	echo "<cert>" >> ~/$1-withoutobfs.ovpn
 	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> ~/$1-withoutobfs.ovpn
 	echo "</cert>" >> ~/$1-withoutobfs.ovpn


### PR DESCRIPTION
## Summary
- avoid writing `<ca>` twice in newclientwithout functions

## Testing
- `shellcheck setup.sh setup_UDP.sh`

------
https://chatgpt.com/codex/tasks/task_e_68424a24ce04832ca6ba15bce5f2d0f5